### PR TITLE
Support organizations with an AI opt-out policy

### DIFF
--- a/source/operators/transcribe/start_transcribe.py
+++ b/source/operators/transcribe/start_transcribe.py
@@ -128,6 +128,7 @@ def lambda_handler(event, context):
     transcribe_job_config["MediaFormat"] = file_type
     transcribe_job_config["LanguageCode"] = language_code
     transcribe_job_config["IdentifyLanguage"] = identify_language
+    transcribe_job_config["OutputBucketName"] = bucket
     if len(optional_settings) > 0:
         transcribe_job_config["Settings"] = optional_settings
     if len(model_settings) > 0:


### PR DESCRIPTION
*Issue #, if available:*

#699 

*Description of changes:*

Lets just always save transcribe results to the root of the dataplane bucket instead of using a bucket hosted by the transcribe service.

Fixes this error:
```
An error occurred (BadRequestException) when calling the StartTranscriptionJob operation: You must specify a value for outputBucketName because your account, XXXXXXXXX, has opted out of using your content for quality improvements. Make sure you provide a value for outputBucketName and try your request again.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
