### PR TITLE
Handle queued MediaConvert job in CheckThumbnailFunction function

### DIFF
--- a/source/operators/thumbnail/check_thumbnail.py
+++ b/source/operators/thumbnail/check_thumbnail.py
@@ -57,7 +57,7 @@ def lambda_handler(event, context):
         operator_object.add_workflow_metadata(MediaconvertError=e, MediaconvertJobId=job_id)
         raise MasExecutionError(operator_object.return_output_object())
     else:
-        if response["Job"]["Status"] == 'IN_PROGRESS' or response["Job"]["Status"] == 'PROGRESSING':
+        if response["Job"]["Status"] == 'IN_PROGRESS' or response["Job"]["Status"] == 'PROGRESSING' or response["Job"]["Status"] == 'SUBMITTED':
             operator_object.update_workflow_status("Executing")
             operator_object.add_workflow_metadata(MediaconvertJobId=job_id, MediaconvertInputFile=input_file, AssetId=asset_id, WorkflowExecutionId=workflow_id)
             return operator_object.return_output_object()


### PR DESCRIPTION
*Issue #, if available:*

The Lambda function CheckThumbnailFunction fails when checking the status of the MediaConvert job that is still queued (status: SUBMITTED). 

*Description of changes:*

This PR adds a check in the condition to support this status. When the MediaConvert job is still queued, it will be handled the same way as it was still being processed by MediaConvert.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
